### PR TITLE
A more informative error message

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,6 +24,7 @@ function loadAndParseConfig(filePath) {
       : {}
   } catch (ex) {
     console.error('Error opening config file ' + filePath)
+    console.error(ex)
     process.exit(1)
   }
 }


### PR DESCRIPTION
I was losing my mind trying to figure out why the file wasn't found or accessible. This was my config file

```
{
  indent: 4
}
```

And with this change you get:

```
Error opening config file C:\User....
[SyntaxError: Unexpected token i]
```

Which was what allowed me to figure out that JSON syntax was the problem.
