### PR TITLE
config to control escapeless

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@
         json: false,
         renumber: false,
         quotes: has('quotmark', 'single'),
-        escapeless: false,
+        escapeless: has('escapeless', false),
         parentheses: true,
         semicolons: !has('asi', false)
       },


### PR DESCRIPTION
if `option.format.escapeless`  set false, chinese '中文' will be escape to '\u4e2d\u6587' , it's unwanted

but no external config can control `escapeless` option in `fixmyjs`

so i add this config 

thanks
