### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "minimatch": "^1.0.0"
   },
   "devDependencies": {
-    "testla": "0.1.x"
+    "testla": "^0.1.x"
   },
   "preferGlobal": true,
   "scripts": {


### PR DESCRIPTION
Noticed a few of the deps could be updated:

esprima (package: ~1.0.4, latest: 1.2.2)
commander (package: ~2.0.0, latest: 2.3.0)
minimatch (package: ~0.2.12, latest: 1.0.0)
escodegen (package: ~0.0.28, latest: 1.4.1)
jshint (package: ~2.3.0, latest: 2.5.6)

May want to test against Windows given dependency versions have been pinned in the past (e.g https://github.com/jshint/fixmyjs/commit/175a35c09437b303cbd1e6a59bca5ded7cd93848). 

cc @XhmikosR 
