### PR TITLE
do not remove new if it is inside a function call

### DIFF
--- a/lib/rules/newSideEffects.js
+++ b/lib/rules/newSideEffects.js
@@ -3,7 +3,7 @@ module.exports = {
 }
 
 function noSideEffects(node, parent) {
-  if (parent.type !== 'ExpressionStatement') {
+  if (parent.type !== 'ExpressionStatement' || parent.expression.type === 'CallExpression') {
     return node
   }
 

--- a/test/new-as-side-effects-test.js
+++ b/test/new-as-side-effects-test.js
@@ -12,6 +12,18 @@ module.exports = function (f, l, assert) {
       var code = 'new Foo;'
       var result = 'Foo();'
       assert.equal(f(code, options), result)
+    },
+
+    'new as function parameter': function () {
+      var code = 'c(new Foo());'
+      var result = 'c(new Foo());'
+      assert.equal(f(code, options), result)
+    },
+
+    'new as function parameter without parens': function () {
+      var code = 'c(new Foo);'
+      var result = 'c(new Foo());'
+      assert.equal(f(code, options), result)
     }
   }
 }


### PR DESCRIPTION
this pull request fix this wrong rewrite
`c(new Foo());`  => `c(Foo());`
it just checks if `parent.expression.type === 'CallExpression'` in case `parent.type === 'ExpressionStatement'`
I'm not sure if there are other expression types inside ExpressionStatement that should be ignored too on newSideEffects rule
