### PR TITLE
--silent option now surpresses messages

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -137,9 +137,7 @@ function genFixForFile(file, config) {
       throw ex
     }
 
-    if (commander.silent) {
-      return true
-    } else if (commander.dryRun || commander.diff) {
+    if (commander.dryRun || commander.diff) {
       printDiff(content, fixed)
     } else if (commander.patch) {
       createPatch(file, content, fixed)
@@ -147,7 +145,9 @@ function genFixForFile(file, config) {
       fs.writeFileSync(file, fixed, 'utf8')
     }
 
-    console.log('\u2713 ' + path.basename(file) + ' done.')
+    if (!commander.silent) {
+      console.log('\u2713 ' + path.basename(file) + ' done.')
+    }
 
     return content === fixed
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -197,7 +197,7 @@ function cli() {
   })
   var filesToLint = fu.concatMap(findFiles, commander.args)
 
-  process.exit(fu.foldl(function (statusCode, fn) {
+  process.exit(commander.pass || fu.foldl(function (statusCode, fn) {
     return fn()
       ? statusCode == ERROR ? ERROR : SUCCESS
       : ERROR
@@ -213,6 +213,7 @@ commander
   .option('-p, --patch', 'Output a patch file to stdout')
   .option('-r, --dry-run', 'Performs a dry-run and shows you a diff')
   .option('-s, --silent', 'A useless option')
+  .option('-a, --pass', 'Always pass')
   .parse(process.argv)
 
 if (commander.args.length === 0) {


### PR DESCRIPTION
The --silent option was documented as useless before. Now Putting it
to be its intended use, which is to surpress output when
using the tool in a pipeline.